### PR TITLE
Use page title as category name

### DIFF
--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Plugin home')
+@section('title', $category->name)
 
 @section('content')
     <div class="container content">


### PR DESCRIPTION
Use the category name in the category page title.
This allows users to understand where the page is located by the page title.