### PR TITLE
Use home title as plugin title

### DIFF
--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Plugin home')
+@section('title', trans('wiki::messages.title'))
 
 @section('content')
     <div class="container content">


### PR DESCRIPTION
This makes the navbar and page title the same.
Use trans('wiki::messages.title') instead of 'Plugin home' for the title of the wiki home.
