### PR TITLE
Don't fully refresh page when changing wiki's page

### DIFF
--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -47,7 +47,7 @@
             tab.show();
 
             if (replaceState) {
-                history.replaceState({}, '', element.href);
+                window.history.replaceState({}, '', element.href);
             } else {
                 window.history.pushState({}, '', element.href);
             }

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -12,8 +12,7 @@
                     <a href="{{ route('wiki.pages.show', [$page->category, $catPage]) }}" class="list-group-item @if($page->is($catPage)) active @endif"
                        title="{{ $catPage->title }}"
                        onclick="selectWikiPage(this)"
-                       data-bs-toggle="tab" role="tab"
-                       data-bs-target="#page-{{ $catPage->id }}"
+                       data-bs-toggle="tab" data-bs-target="#page-{{ $catPage->id }}" role="tab"
                        aria-controls="page-{{ $catPage->id }}" aria-selected="{{ $page->is($catPage) ? 'true' : 'false' }}">
                         {{ $catPage->title }}
                     </a>

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -52,5 +52,8 @@
                 action(div);
             }
         }
+        window.onpopstate = function(e) {
+            window.location.pathname = e.target.location.pathname;
+        };
     </script>
 @endpush

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -9,7 +9,7 @@
         <div class="col-md-3">
             <div class="list-group mb-3" role="tablist">
                 @foreach($page->category->pages as $catPage)
-                    <a class="list-group-item @if($page->is($catPage)) active @endif" id="page-list-{{ $catPage->id }}" onclick="select({{ $catPage->id }})">
+                    <a class="list-group-item @if($page->is($catPage)) active @endif" id="page-list-{{ $catPage->id }}" onclick="select({{ $catPage->id }}, '{{ $catPage->slug }}')">
                         {{ $catPage->title }}
                     </a>
                 @endforeach
@@ -36,13 +36,14 @@
     <script>
         var focusPage = {{ $page->id }};
 
-        function select(pageId) {
+        function select(pageId, catLink) {
             changeIfExist("page-" + focusPage, function (div) { div.style.display = 'none'; });
             changeIfExist("page-list-" + focusPage, function (div) { div.classList.remove("active"); });
 
             changeIfExist("page-" + pageId, function (div) { div.style.display = null; });
             changeIfExist("page-list-" + pageId, function (div) { div.classList.add("active"); });
             focusPage = pageId;
+            window.history.pushState(null, null, catLink);
         }
 
         function changeIfExist(name, action) {

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -9,7 +9,7 @@
         <div class="col-md-3">
             <div class="list-group mb-3" role="tablist">
                 @foreach($page->category->pages as $catPage)
-                    <a href="{{ route('wiki.pages.show', [$page->category, $catPage]) }}" class="list-group-item @if($page->is($catPage)) active @endif">
+                    <a class="list-group-item @if($page->is($catPage)) active @endif" id="page-list-{{ $catPage->id }}" onclick="select({{ $catPage->id }})">
                         {{ $catPage->title }}
                     </a>
                 @endforeach
@@ -21,11 +21,35 @@
         </div>
 
         <div class="col-md-9">
-            <div class="card">
-                <div class="card-body">
-                    {!! $page->content !!}
+            @foreach($page->category->pages as $catPage)
+                <div class="card card-wiki" id="page-{{ $catPage->id }}" @if($catPage->id != $page->id) style="display: none;" @endif>
+                    <div class="card-body">
+                        {!! $catPage->content !!}
+                    </div>
                 </div>
-            </div>
+            @endforeach
         </div>
     </div>
 @endsection
+
+@push('scripts')
+    <script>
+        var focusPage = {{ $page->id }};
+
+        function select(pageId) {
+            changeIfExist("page-" + focusPage, function (div) { div.style.display = 'none'; });
+            changeIfExist("page-list-" + focusPage, function (div) { div.classList.remove("active"); });
+
+            changeIfExist("page-" + pageId, function (div) { div.style.display = null; });
+            changeIfExist("page-list-" + pageId, function (div) { div.classList.add("active"); });
+            focusPage = pageId;
+        }
+
+        function changeIfExist(name, action) {
+            let div = document.getElementById(name);
+            if(div != null) {
+                action(div);
+            }
+        }
+    </script>
+@endpush


### PR DESCRIPTION
The objective is to navigate over all page of a category without the time and the flash of complete one.

You can test it [here](https://azurium.infinitymc.fr/wiki/test/a)

This change the URL to stay the same as the user will be if he refresh the page.

The `focusPage` is to don't have to search over all card if it's well disabled/enabled, or search by class name.